### PR TITLE
fix <App/> path missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { useFetch } from "./useFetch";
-import {App} from './index'
+import {App} from './App'
 
 
 const rootElement = document.getElementById("root");


### PR DESCRIPTION
# Overview
Thank you for cool example!
I fixed `yarn start` failed because include path missing.

## Problem
<img width="531" alt="Screen Shot 2019-09-10 at 6 34 42" src="https://user-images.githubusercontent.com/5501268/64568527-ebbb0180-d395-11e9-86f6-62b50be05388.png">



## After fixed
<img width="594" alt="Screen Shot 2019-09-10 at 6 41 53" src="https://user-images.githubusercontent.com/5501268/64568608-22911780-d396-11e9-8b2b-c58afd000363.png">
